### PR TITLE
chore: migrate environment config to Infisical

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ next-env.d.ts
 # public/images/*.mp4
 # public/videos/*.mp4
 config.bat
+
+# Secrets are injected by Infisical; plaintext env files are forbidden.
+.env*

--- a/README.md
+++ b/README.md
@@ -64,11 +64,7 @@ npm install
 
 ### Environment variables
 
-Copy the sample file and fill in your values:
-
-```bash
-cp .env.sample .env.local
-```
+Store these values under `/dubio--web` in Infisical; the npm scripts inject them.
 
 | Variable | Description |
 | --- | --- |

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build",
-    "start": "next start",
+    "dev": "infisical run --projectId=98ac6ff9-be43-46a1-8fbf-131e217bccd3 --env=${INFISICAL_ENV:-dev} --path=/dubio--web -- next dev --turbopack",
+    "build": "infisical run --projectId=98ac6ff9-be43-46a1-8fbf-131e217bccd3 --env=${INFISICAL_ENV:-dev} --path=/dubio--web -- next build",
+    "start": "infisical run --projectId=98ac6ff9-be43-46a1-8fbf-131e217bccd3 --env=${INFISICAL_ENV:-dev} --path=/dubio--web -- next start",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- inject runtime configuration from Infisical
- remove plaintext env files and dotenv loaders
- prevent local env files from returning

## Verification
- secret counts verified in Infisical
- available typecheck/lint checks run